### PR TITLE
feature : 상품 상세 조회

### DIFF
--- a/backend/src/main/java/wap/dingdong/backend/controller/AuthController.java
+++ b/backend/src/main/java/wap/dingdong/backend/controller/AuthController.java
@@ -16,10 +16,10 @@ import org.springframework.web.servlet.support.ServletUriComponentsBuilder;
 import wap.dingdong.backend.exception.BadRequestException;
 import wap.dingdong.backend.domain.AuthProvider;
 import wap.dingdong.backend.domain.User;
-import wap.dingdong.backend.payload.ApiResponse;
-import wap.dingdong.backend.payload.AuthResponse;
-import wap.dingdong.backend.payload.LoginRequest;
-import wap.dingdong.backend.payload.SignUpRequest;
+import wap.dingdong.backend.security.oauth2.payload.response.ApiResponse;
+import wap.dingdong.backend.security.oauth2.payload.response.AuthResponse;
+import wap.dingdong.backend.security.oauth2.payload.request.LoginRequest;
+import wap.dingdong.backend.security.oauth2.payload.request.SignUpRequest;
 import wap.dingdong.backend.repository.UserRepository;
 import wap.dingdong.backend.security.TokenProvider;
 

--- a/backend/src/main/java/wap/dingdong/backend/controller/CommentController.java
+++ b/backend/src/main/java/wap/dingdong/backend/controller/CommentController.java
@@ -4,8 +4,12 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
+import wap.dingdong.backend.domain.User;
 import wap.dingdong.backend.payload.request.CommentRequest;
 import wap.dingdong.backend.payload.response.CommentResponse;
+import wap.dingdong.backend.security.CurrentUser;
+import wap.dingdong.backend.security.UserPrincipal;
+import wap.dingdong.backend.service.CommentService;
 import wap.dingdong.backend.service.ProductService;
 
 import java.util.List;
@@ -14,20 +18,20 @@ import java.util.List;
 @RestController
 public class CommentController {
 
-    @Autowired
-    private ProductService productService;
+    private final CommentService commentService;
 
-    // 댓글 조회
-    @GetMapping("/product/{productId}/comment")
-    public ResponseEntity<List<CommentResponse>> getAllCommentsForBoard(@PathVariable Long productId) {
-        List<CommentResponse> comments = productService.getAllCommentsForBoard(productId);
-        return ResponseEntity.ok(comments);
-    }
+//    // 댓글 조회 (상품 상세 조회가 댓글 조회임으로 제외)
+//    @GetMapping("/product/{productId}/comment")
+//    public ResponseEntity<List<CommentResponse>> getAllCommentsForBoard(@PathVariable Long productId) {
+//        List<CommentResponse> comments = productService.getAllCommentsForBoard(productId);
+//        return ResponseEntity.ok(comments);
+//    }
     // 댓글 생성
     @PostMapping("/product/{productId}/comment")
     public ResponseEntity<CommentResponse> createComment(
-            @PathVariable Long productId, @RequestBody CommentRequest commentDto) {
-        CommentResponse createdComment = productService.createComment(productId, commentDto);
+            @PathVariable Long productId, @RequestBody CommentRequest commentDto,
+            @CurrentUser UserPrincipal userPrincipal) {
+        CommentResponse createdComment = commentService.createComment(productId, commentDto, userPrincipal);
         return ResponseEntity.ok(createdComment);
     }
 }

--- a/backend/src/main/java/wap/dingdong/backend/controller/ProductController.java
+++ b/backend/src/main/java/wap/dingdong/backend/controller/ProductController.java
@@ -3,12 +3,10 @@ package wap.dingdong.backend.controller;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 import wap.dingdong.backend.payload.request.ProductCreateRequest;
 import wap.dingdong.backend.payload.response.ProductInfoResponse;
+import wap.dingdong.backend.payload.response.ProductDetailResponse;
 import wap.dingdong.backend.payload.response.ProductsResponse;
 import wap.dingdong.backend.security.CurrentUser;
 import wap.dingdong.backend.security.UserPrincipal;
@@ -40,5 +38,14 @@ public class ProductController {
         ProductsResponse response = new ProductsResponse(products);
         return new ResponseEntity<>(response, HttpStatus.OK);
     }
+
+    //상품 상세보기
+    @GetMapping("/product/{productId}")
+    public ResponseEntity<?> getBookDetails(@PathVariable Long productId) {
+        ProductDetailResponse response = productService.getProductDetails(productId);
+        return new ResponseEntity<>(response, HttpStatus.OK);
+    }
+
+
 
 }

--- a/backend/src/main/java/wap/dingdong/backend/controller/UserController.java
+++ b/backend/src/main/java/wap/dingdong/backend/controller/UserController.java
@@ -1,5 +1,6 @@
 package wap.dingdong.backend.controller;
 
+import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RestController;
@@ -10,10 +11,10 @@ import wap.dingdong.backend.security.CurrentUser;
 import wap.dingdong.backend.security.UserPrincipal;
 
 @RestController
+@RequiredArgsConstructor
 public class UserController {
 
-    @Autowired
-    private UserRepository userRepository;
+    private final UserRepository userRepository;
 
     @GetMapping("/user/me") //@CurrentUser : 프론트에서 주는 토큰을 가지고 객체를 만들어줌
     public User getCurrentUser(@CurrentUser UserPrincipal userPrincipal) {

--- a/backend/src/main/java/wap/dingdong/backend/domain/Comment.java
+++ b/backend/src/main/java/wap/dingdong/backend/domain/Comment.java
@@ -21,7 +21,6 @@ public class Comment {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     @Column(name = "comment_id")
-
     private Long cmtId; // 변수명 수정
 
     private String cmtContent; // 변수명 수정
@@ -37,5 +36,10 @@ public class Comment {
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "user_id")
     private User user;
+
+    public Comment(String cmtContent, User user) {
+        this.cmtContent = cmtContent;
+        this.user = user;
+    }
 
 }

--- a/backend/src/main/java/wap/dingdong/backend/exception/ResourceNotFoundException.java
+++ b/backend/src/main/java/wap/dingdong/backend/exception/ResourceNotFoundException.java
@@ -16,6 +16,10 @@ public class ResourceNotFoundException extends RuntimeException {
         this.fieldValue = fieldValue;
     }
 
+    public ResourceNotFoundException(String message) {
+        super(message);
+    }
+
     public String getResourceName() {
         return resourceName;
     }

--- a/backend/src/main/java/wap/dingdong/backend/payload/CommentDto.java
+++ b/backend/src/main/java/wap/dingdong/backend/payload/CommentDto.java
@@ -1,0 +1,16 @@
+package wap.dingdong.backend.payload;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor @AllArgsConstructor
+public class CommentDto {
+    private Long cmtId;
+    private Long userId;
+    private String email;
+    private String cmtContent;
+
+
+}

--- a/backend/src/main/java/wap/dingdong/backend/payload/response/ProductDetailResponse.java
+++ b/backend/src/main/java/wap/dingdong/backend/payload/response/ProductDetailResponse.java
@@ -1,0 +1,54 @@
+package wap.dingdong.backend.payload.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import wap.dingdong.backend.domain.Product;
+import wap.dingdong.backend.payload.CommentDto;
+import wap.dingdong.backend.payload.ImageDto;
+import wap.dingdong.backend.payload.LocationDto;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Getter
+@AllArgsConstructor @NoArgsConstructor
+public class ProductDetailResponse {
+
+    private String email;
+    private Long productId;
+    private String title;
+    private Long price;
+    private String contents;
+    private List<LocationDto> locations;
+    private String status;
+    private List<ImageDto> image;
+    private String productLike;
+    private LocalDateTime createdAt;
+    private List<CommentDto> comment;
+
+    public static ProductDetailResponse of(Product product) {
+        return new ProductDetailResponse(
+                product.getUser().getEmail(),
+                product.getId(),
+                product.getTitle(),
+                product.getPrice(),
+                product.getContents(),
+                product.getLocations().stream()
+                        .map(location -> new LocationDto(location.getLocation()))
+                        .collect(Collectors.toList()),
+                product.getStatus().toString(),
+                product.getImages().stream()
+                                .map(image -> new ImageDto(image.getImage()))
+                                .collect(Collectors.toList()),
+                product.getProductLike().toString(),
+                product.getCreatedAt(),
+                product.getComments().stream()
+                        .map(comment -> new CommentDto(comment.getCmtId(),comment.getUser().getId(),
+                                comment.getUser().getEmail(), comment.getCmtContent()))
+                        .collect(Collectors.toList())
+        );
+    }
+
+}

--- a/backend/src/main/java/wap/dingdong/backend/security/oauth2/payload/request/LoginRequest.java
+++ b/backend/src/main/java/wap/dingdong/backend/security/oauth2/payload/request/LoginRequest.java
@@ -1,4 +1,4 @@
-package wap.dingdong.backend.payload;
+package wap.dingdong.backend.security.oauth2.payload.request;
 
 import jakarta.validation.constraints.Email;
 import jakarta.validation.constraints.NotBlank;

--- a/backend/src/main/java/wap/dingdong/backend/security/oauth2/payload/request/SignUpRequest.java
+++ b/backend/src/main/java/wap/dingdong/backend/security/oauth2/payload/request/SignUpRequest.java
@@ -1,4 +1,4 @@
-package wap.dingdong.backend.payload;
+package wap.dingdong.backend.security.oauth2.payload.request;
 
 import jakarta.validation.constraints.Email;
 import jakarta.validation.constraints.NotBlank;

--- a/backend/src/main/java/wap/dingdong/backend/security/oauth2/payload/response/ApiResponse.java
+++ b/backend/src/main/java/wap/dingdong/backend/security/oauth2/payload/response/ApiResponse.java
@@ -1,4 +1,4 @@
-package wap.dingdong.backend.payload;
+package wap.dingdong.backend.security.oauth2.payload.response;
 
 import lombok.Getter;
 import lombok.Setter;

--- a/backend/src/main/java/wap/dingdong/backend/security/oauth2/payload/response/AuthResponse.java
+++ b/backend/src/main/java/wap/dingdong/backend/security/oauth2/payload/response/AuthResponse.java
@@ -1,4 +1,4 @@
-package wap.dingdong.backend.payload;
+package wap.dingdong.backend.security.oauth2.payload.response;
 
 import lombok.Getter;
 import lombok.Setter;

--- a/backend/src/main/java/wap/dingdong/backend/service/CommentService.java
+++ b/backend/src/main/java/wap/dingdong/backend/service/CommentService.java
@@ -1,0 +1,61 @@
+package wap.dingdong.backend.service;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import wap.dingdong.backend.domain.Comment;
+import wap.dingdong.backend.domain.Product;
+import wap.dingdong.backend.domain.User;
+import wap.dingdong.backend.exception.ResourceNotFoundException;
+import wap.dingdong.backend.payload.request.CommentRequest;
+import wap.dingdong.backend.payload.response.CommentResponse;
+import wap.dingdong.backend.repository.CommentRepository;
+import wap.dingdong.backend.repository.ProductRepository;
+import wap.dingdong.backend.repository.UserRepository;
+import wap.dingdong.backend.security.UserPrincipal;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class CommentService {
+
+    private final ProductRepository productRepository;
+    private final CommentRepository commentRepository;
+    private final UserRepository userRepository;
+
+    // 댓글 작성
+    @Transactional
+    public CommentResponse createComment(Long productId, CommentRequest commentDto, UserPrincipal userPrincipal) {
+        User user = userRepository.findById(userPrincipal.getId()).get();
+
+        Product product = productRepository.findById(productId)
+                .orElseThrow(() -> new ResourceNotFoundException("Product", "id", productId));
+
+        //이미 등록된 상품에 새 댓글을 등록할때는 댓글엔티티의 상품 FK만 적절히 넣으면됨
+        Comment comment = new Comment(commentDto.getCmtContent(), user);
+        comment.setProduct(product);
+
+        Comment savedComment = commentRepository.save(comment);
+        CommentResponse responseDto = new CommentResponse(savedComment);
+        return responseDto;
+    }
+
+//    // 댓글 조회 ( 상품 상세 조회가 댓글 조회이므로 제외)
+//    public List<CommentResponse> getAllCommentsForBoard(Long productId) {
+//        Product product = productRepository.findById(productId)
+//                .orElseThrow(() -> new ResourceNotFoundException("Product", "id", productId));
+//
+//        List<CommentResponse> responseDtoList = new ArrayList<>();
+//        for (Comment comment : product.getComments()) {
+//            CommentResponse responseDto = new CommentResponse(comment);
+//            responseDtoList.add(responseDto);
+//        }
+//
+//        return responseDtoList;
+//    }
+}

--- a/backend/src/main/java/wap/dingdong/backend/service/ProductService.java
+++ b/backend/src/main/java/wap/dingdong/backend/service/ProductService.java
@@ -11,6 +11,7 @@ import wap.dingdong.backend.payload.request.CommentRequest;
 import wap.dingdong.backend.payload.request.ProductCreateRequest;
 import wap.dingdong.backend.payload.response.CommentResponse;
 import wap.dingdong.backend.payload.response.ProductInfoResponse;
+import wap.dingdong.backend.payload.response.ProductDetailResponse;
 import wap.dingdong.backend.payload.response.ProductsResponse;
 import wap.dingdong.backend.repository.CommentRepository;
 import wap.dingdong.backend.repository.ProductRepository;
@@ -27,9 +28,6 @@ public class ProductService {
 
     private final ProductRepository productRepository;
     private final UserRepository userRepository;
-
-    @Autowired
-    private CommentRepository commentRepository;
 
     /*
       상품 등록
@@ -59,7 +57,6 @@ public class ProductService {
         productRepository.save(product);
     }
 
-//===========================================================================================
 
 /*
     모든 상품 조회 (메인페이지 상품 목록)
@@ -70,34 +67,13 @@ public class ProductService {
         return ProductsResponse.of(products); //응답 데이터를 던져야 함으로 DTO 로 변환
     }
 
-
-    /* ------------- 댓글 -------------- */
-
-    // 댓글 작성
-    public CommentResponse createComment(Long productId, CommentRequest commentDto) {
+/*
+    상품 상세 조회
+ */
+    public ProductDetailResponse getProductDetails(Long productId) {
         Product product = productRepository.findById(productId)
-                .orElseThrow(() -> new ResourceNotFoundException("Product", "id", productId));
-
-        Comment comment = commentDto.toEntity();
-        comment.setProduct(product);
-
-        Comment savedComment = commentRepository.save(comment);
-        CommentResponse responseDto = new CommentResponse(savedComment);
-        return responseDto;
-    }
-
-    // 댓글 조회
-    public List<CommentResponse> getAllCommentsForBoard(Long productId) {
-        Product product = productRepository.findById(productId)
-                .orElseThrow(() -> new ResourceNotFoundException("Product", "id", productId));
-
-        List<CommentResponse> responseDtoList = new ArrayList<>();
-        for (Comment comment : product.getComments()) {
-            CommentResponse responseDto = new CommentResponse(comment);
-            responseDtoList.add(responseDto);
-        }
-
-        return responseDtoList;
+                .orElseThrow(() -> new ResourceNotFoundException("Product not found"));
+        return ProductDetailResponse.of(product);
     }
 
 }


### PR DESCRIPTION
커밋 내용 :
1. 로그인 관련 DTO들을 security pakage로 다 옮겨서 분리함
2. 댓글 조회는 곧 상품상세 조회임으로 (상품 상세에 댓글이 달리는 구조라서) 이에 맞춰서 상품상세에 댓글도 보이게함, 이 과정에서 안쓰이는 메서드들을 주석처리해놨음
3. 댓글관련 서비스 로직을 따로 서비스 클래스를 만들어서 분리함
4. 댓글 포함 모든 기능에 로그인한 유저가 필요한 경우를 다 적용시킴 (등록)
5. CommentService 코드를 살짝 바꿨음 (toEntity 메서드를 안쓰고 바로 생성자로 넣었음, 로그인한 유저를 넣으려다 보니까 바꿨음)

질문 : @sihyeon-an 댓글 생성때 혹시 응답데이터를 프런트에 보내는 이유가 따로 있어??