### PR TITLE
refactor : 찜하기 수정

### DIFF
--- a/backend/src/main/java/wap/dingdong/backend/controller/ProductController.java
+++ b/backend/src/main/java/wap/dingdong/backend/controller/ProductController.java
@@ -4,6 +4,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
+import wap.dingdong.backend.domain.User;
 import wap.dingdong.backend.payload.request.ProductCreateRequest;
 import wap.dingdong.backend.payload.response.ProductInfoResponse;
 import wap.dingdong.backend.payload.response.ProductResponse;
@@ -29,11 +30,18 @@ public class ProductController {
         return new ResponseEntity<>(HttpStatus.OK);
     }
 
-    // 상품 상세보기
-    //@GetMapping("/product/{productId}")
-    public ResponseEntity<ProductResponse> getProductByProductId(@PathVariable Long productId) {
-        ProductResponse productResponse = productService.getProduct(productId);
-        return ResponseEntity.ok(productResponse);
+//    // 상품 상세보기
+//    //@GetMapping("/product/{productId}")
+//    public ResponseEntity<ProductResponse> getProductByProductId(@PathVariable Long productId) {
+//        ProductResponse productResponse = productService.getProduct(productId);
+//        return ResponseEntity.ok(productResponse);
+//    }
+
+    //상품 상세보기
+    @GetMapping("/product/{productId}")
+    public ResponseEntity<?> getBookDetails(@PathVariable Long productId) {
+        ProductDetailResponse response = productService.getProductDetails(productId);
+        return new ResponseEntity<>(response, HttpStatus.OK);
     }
 
     // 전체 상품 조회
@@ -47,13 +55,7 @@ public class ProductController {
         return new ResponseEntity<>(response, HttpStatus.OK);
     }
 
-    // 상품 찜하기 기능
-    @PostMapping("/product/{productId}/like")
-    public ResponseEntity<ProductResponse> likeProduct(@PathVariable Long productId, @RequestHeader("user_id") Long user_id) {
-        ProductResponse likedProduct = productService.likeProduct(productId, user_id);
-        return ResponseEntity.ok(likedProduct);
-    }
-
+    //전체 상품 조회 (페이지네이션)
     // ex) page=1 을보내면  최신순으로 첫번째 에서 8번째까지 상품 목록을 리스트로 반환함 , page=2 는 9번째부터 16번째
     @GetMapping("/product/list/recent")
     public ResponseEntity<?> findRecentUserBooks(@RequestParam int page) {
@@ -63,11 +65,14 @@ public class ProductController {
         return new ResponseEntity<>(response, HttpStatus.OK);
     }
 
-    //상품 상세보기
-    @GetMapping("/product/{productId}")
-    public ResponseEntity<?> getBookDetails(@PathVariable Long productId) {
-        ProductDetailResponse response = productService.getProductDetails(productId);
-        return new ResponseEntity<>(response, HttpStatus.OK);
+    // 상품 찜하기 기능
+    @PostMapping("/product/{productId}/like")
+    public ResponseEntity<ProductResponse> likeProduct(@PathVariable Long productId,
+                                                       @CurrentUser UserPrincipal userPrincipal) {
+        ProductResponse likedProduct = productService.likeProduct(productId, userPrincipal);
+        return ResponseEntity.ok(likedProduct);
     }
+
+
 
 }

--- a/backend/src/main/java/wap/dingdong/backend/controller/ProductController.java
+++ b/backend/src/main/java/wap/dingdong/backend/controller/ProductController.java
@@ -70,6 +70,4 @@ public class ProductController {
         return new ResponseEntity<>(response, HttpStatus.OK);
     }
 
-
-
 }

--- a/backend/src/main/java/wap/dingdong/backend/domain/Comment.java
+++ b/backend/src/main/java/wap/dingdong/backend/domain/Comment.java
@@ -37,9 +37,10 @@ public class Comment {
     @JoinColumn(name = "user_id")
     private User user;
 
-    public Comment(String cmtContent, User user) {
+    public Comment(String cmtContent, User user, Product product) {
         this.cmtContent = cmtContent;
         this.user = user;
+        this.product = product;
     }
 
 }

--- a/backend/src/main/java/wap/dingdong/backend/payload/response/ProductDetailResponse.java
+++ b/backend/src/main/java/wap/dingdong/backend/payload/response/ProductDetailResponse.java
@@ -25,7 +25,7 @@ public class ProductDetailResponse {
     private String status;
     private List<ImageDto> image;
     private String productLike;
-    private LocalDateTime createdAt;
+    private String createdAt;
     private List<CommentDto> comment;
 
     public static ProductDetailResponse of(Product product) {
@@ -43,7 +43,7 @@ public class ProductDetailResponse {
                                 .map(image -> new ImageDto(image.getImage()))
                                 .collect(Collectors.toList()),
                 product.getProductLike().toString(),
-                product.getCreatedAt(),
+                product.getCreatedAt().toString(),
                 product.getComments().stream()
                         .map(comment -> new CommentDto(comment.getCmtId(),comment.getUser().getId(),
                                 comment.getUser().getEmail(), comment.getCmtContent()))

--- a/backend/src/main/java/wap/dingdong/backend/service/CommentService.java
+++ b/backend/src/main/java/wap/dingdong/backend/service/CommentService.java
@@ -37,8 +37,7 @@ public class CommentService {
                 .orElseThrow(() -> new ResourceNotFoundException("Product", "id", productId));
 
         //이미 등록된 상품에 새 댓글을 등록할때는 댓글엔티티의 상품 FK만 적절히 넣으면됨
-        Comment comment = new Comment(commentDto.getCmtContent(), user);
-        comment.setProduct(product);
+        Comment comment = new Comment(commentDto.getCmtContent(), user, product);
 
         Comment savedComment = commentRepository.save(comment);
         CommentResponse responseDto = new CommentResponse(savedComment);

--- a/backend/src/main/java/wap/dingdong/backend/service/ProductService.java
+++ b/backend/src/main/java/wap/dingdong/backend/service/ProductService.java
@@ -51,7 +51,7 @@ public class ProductService {
         Product product = new Product(user, request.getTitle(), request.getPrice(),
                 request.getContents(), locations, images);
 
-        // 양방향 연관관계 데이터 일관성 유지
+        // 양방향 연관관계 데이터 일관성 유지 : 연관관계의 주인이 아닌쪽의 엔티티가 변경되었을때 연관관계의 주인의 엔티티도 set
         locations.forEach(location -> location.updateProduct(product));
         images.forEach(image -> image.updateProduct(product));
 
@@ -75,31 +75,20 @@ public class ProductService {
         return new ProductResponse(product);
     }
 
-    /* ------------- 댓글 -------------- */
 
-    // 댓글 작성
-    public CommentResponse createComment(Long id, CommentRequest commentDto) {
-        Product product = productRepository.findById(id)
-                .orElseThrow(() -> new ResourceNotFoundException("Product", "id", id));
-
-        Comment comment = commentDto.toEntity();
-        comment.setProduct(product);
-
-        Comment savedComment = commentRepository.save(comment);
-        CommentResponse responseDto = new CommentResponse(savedComment);
-        return responseDto;
-    }
 
     // 댓글 조회
-    public List<CommentResponse> getAllCommentsForBoard(Long id) {
-        Product product = productRepository.findById(id)
-                .orElseThrow(() -> new ResourceNotFoundException("Product", "id", id));
+//    public List<CommentResponse> getAllCommentsForBoard(Long id) {
+//        Product product = productRepository.findById(id)
+//                .orElseThrow(() -> new ResourceNotFoundException("Product", "id", id));
+//
+//        List<CommentResponse> responseDtoList = new ArrayList<>();
+//        for (Comment comment : product.getComments()) {
+//            CommentResponse responseDto = new CommentResponse(comment);
+//            responseDtoList.add(responseDto);
+//        }
+//    }
 
-        List<CommentResponse> responseDtoList = new ArrayList<>();
-        for (Comment comment : product.getComments()) {
-            CommentResponse responseDto = new CommentResponse(comment);
-            responseDtoList.add(responseDto);
-        }
     // 페이지네이션된 책 리스트 가져오기
     public List<ProductInfoResponse> getRecentPaginatedProducts(int page, int size) {
         int offset = (page - 1) * size;
@@ -121,7 +110,8 @@ public class ProductService {
         return ProductDetailResponse.of(product);
     }
 
-    /* ------------- 상품 찜하기 -------------- */
+    /* ------------- 상품 찜하기 (상품의 productLike 수정) ------------- */
+
     public ProductResponse likeProduct(Long id, Long user_id) {
         Product product = productRepository.findById(id)
                 .orElseThrow(() -> new RuntimeException("게시글을 찾을 수 없습니다."));
@@ -137,3 +127,6 @@ public class ProductService {
     }
 
 }
+
+
+

--- a/backend/src/main/java/wap/dingdong/backend/service/ProductService.java
+++ b/backend/src/main/java/wap/dingdong/backend/service/ProductService.java
@@ -112,14 +112,17 @@ public class ProductService {
 
     /* ------------- 상품 찜하기 (상품의 productLike 수정) ------------- */
 
-    public ProductResponse likeProduct(Long id, Long user_id) {
+    public ProductResponse likeProduct(Long id, UserPrincipal userPrincipal) {
+        User user = userRepository.findById(userPrincipal.getId())
+                .orElseThrow(() -> new ResourceNotFoundException("User", "id", userPrincipal.getId()));
+
         Product product = productRepository.findById(id)
                 .orElseThrow(() -> new RuntimeException("게시글을 찾을 수 없습니다."));
 
-        if (product.isLikedByMember(user_id)) {
-            product.decreaseLike(user_id); // 찜하기 취소
+        if (product.isLikedByMember(user.getId())) {
+            product.decreaseLike(user.getId()); // 찜하기 취소
         } else {
-            product.increaseLike(user_id); // 찜하기 추가
+            product.increaseLike(user.getId()); // 찜하기 추가
         }
 
         Product likedProduct = productRepository.save(product);


### PR DESCRIPTION
1. 찜하기때 요청으로 userid를 헤더로 주는 방식이 아닌 헤더에 가지고있는 토큰으로 요청을 하게 변경
@CurrentUser 을 이용하여 가능함, 이렇게하면 프런트에서 더 편함 (헤더에 토큰만 가지고 있으면 되므로)

<이전 pr때 변경사항 리마인드>
1. 로그인 관련 DTO들을 security pakage로 다 옮겨서 분리함
2. 댓글 조회는 곧 상품상세 조회임으로 (상품 상세에 댓글이 달리는 구조라서) 이에 맞춰서 상품상세에 댓글도 보이게함, 이 과정에서 안쓰이는 
    메서드들을 주석처리해놨음
3. 댓글관련 서비스 로직을 따로 서비스 클래스를 만들어서 분리함
4. GET/product 가 포함된 요청은 헤더에 토큰 필요없음
5. CommentService 코드를 살짝 바꿨음 (toEntity 메서드를 안쓰고 바로 생성자로 넣었음, 로그인한 유저를 넣으려다 보니까 바꿨음)