### PR TITLE
base64방식 이미지 업로드

### DIFF
--- a/backend/src/main/java/wap/dingdong/backend/controller/ProductController.java
+++ b/backend/src/main/java/wap/dingdong/backend/controller/ProductController.java
@@ -4,7 +4,9 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
+import org.springframework.web.multipart.MultipartFile;
 import wap.dingdong.backend.domain.User;
+import wap.dingdong.backend.payload.ImageDto;
 import wap.dingdong.backend.payload.request.ProductCreateRequest;
 import wap.dingdong.backend.payload.response.ProductInfoResponse;
 import wap.dingdong.backend.payload.response.ProductResponse;
@@ -14,7 +16,11 @@ import wap.dingdong.backend.security.CurrentUser;
 import wap.dingdong.backend.security.UserPrincipal;
 import wap.dingdong.backend.service.ProductService;
 
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.Base64;
 import java.util.List;
+import java.util.stream.Collectors;
 
 @RequiredArgsConstructor
 @RestController
@@ -23,12 +29,22 @@ public class ProductController {
     private final ProductService productService;
 
     //상품 등록
+//    @PostMapping("/product")
+//    public ResponseEntity<?> createProduct(@CurrentUser UserPrincipal userPrincipal, //User 와 요청 DTO 를 별개로 취급
+//                                           @RequestBody ProductCreateRequest request) {
+//        productService.save(userPrincipal, request);
+//        return new ResponseEntity<>(HttpStatus.OK);
+//    }
+
     @PostMapping("/product")
-    public ResponseEntity<?> createProduct(@CurrentUser UserPrincipal userPrincipal, //User 와 요청 DTO 를 별개로 취급
-                                           @RequestBody ProductCreateRequest request) {
-        productService.save(userPrincipal, request);
+    public ResponseEntity<?> createProduct(@CurrentUser UserPrincipal userPrincipal,
+                                           @RequestPart("product") ProductCreateRequest request,
+                                           @RequestPart("images") List<MultipartFile> images) {
+        productService.save(userPrincipal, request, images);
         return new ResponseEntity<>(HttpStatus.OK);
     }
+
+
 
 //    // 상품 상세보기
 //    //@GetMapping("/product/{productId}")

--- a/backend/src/main/java/wap/dingdong/backend/domain/Image.java
+++ b/backend/src/main/java/wap/dingdong/backend/domain/Image.java
@@ -17,6 +17,7 @@ public class Image {
     @Column(name = "image_id")
     private Long id;
 
+    @Column(columnDefinition = "LONGTEXT")
     private String image;
 
     @ManyToOne(fetch = FetchType.LAZY)

--- a/backend/src/main/java/wap/dingdong/backend/payload/ImageDto.java
+++ b/backend/src/main/java/wap/dingdong/backend/payload/ImageDto.java
@@ -1,5 +1,6 @@
 package wap.dingdong.backend.payload;
 
+import jakarta.persistence.Column;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -8,5 +9,6 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor
 @AllArgsConstructor
 public class ImageDto {
+    @Column(columnDefinition = "LONGTEXT")
     private String image;
 }

--- a/backend/src/main/java/wap/dingdong/backend/payload/request/ProductCreateRequest.java
+++ b/backend/src/main/java/wap/dingdong/backend/payload/request/ProductCreateRequest.java
@@ -3,11 +3,8 @@ package wap.dingdong.backend.payload.request;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-import lombok.Setter;
-import wap.dingdong.backend.domain.Product;
-import wap.dingdong.backend.payload.ImageDto;
 import wap.dingdong.backend.payload.LocationDto;
-import wap.dingdong.backend.security.UserPrincipal;
+import org.springframework.web.multipart.MultipartFile;
 
 import java.util.List;
 
@@ -15,12 +12,9 @@ import java.util.List;
 @NoArgsConstructor
 @AllArgsConstructor
 public class ProductCreateRequest {
-
     private String title;
     private Long price;
     private String contents;
     private List<LocationDto> locations;
-    private List<ImageDto> images;
-
-
+    private List<MultipartFile> images; // 이미지 데이터를 MultipartFile 타입으로 수정
 }


### PR DESCRIPTION
# *base64 이미지 업로드
## 프런트
- multipart/form-data 형식으로 요청데이터를 보내야함 (바디에 다른형식의 데이터들을 분리해서 한번에 방식)
- http body에 이미지에 해당하는 MultipartFile과 나머지 JSON을 각각 보내야함
- 이미지는 base64인코딩된 문자열로 저장되고 이 문자열은 길이가 매우김 그러므로 이에 따른 대비가 필요할 수 있음
--------
## 백
- ddl auto create가 잘 작동이 안되므로 로컬에서 작업 시 application.properties에서 ddl auto를 none으로 설정하고 작업할것
- 배포된 서버에는 어짜피 ddl auto가 none 이므로 문제가 없음
- POSTMAN으로 요청하는 방법은 노션에 써놓음