### PR TITLE
Feature/#98 aws s3 이미지url업로드

### DIFF
--- a/backend/build.gradle
+++ b/backend/build.gradle
@@ -34,6 +34,10 @@ dependencies {
 	annotationProcessor 'org.projectlombok:lombok'
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
 	testImplementation 'org.springframework.security:spring-security-test'
+//	implementation 'com.amazonaws:aws-java-sdk-s3:1.12.261'
+	implementation 'org.springframework.cloud:spring-cloud-starter-aws:2.2.6.RELEASE'
+
+
 
 	implementation group: 'io.jsonwebtoken', name: 'jjwt-api', version: '0.11.2'
 	runtimeOnly group: 'io.jsonwebtoken', name: 'jjwt-impl', version: '0.11.2'

--- a/backend/src/main/java/wap/dingdong/backend/config/S3Config.java
+++ b/backend/src/main/java/wap/dingdong/backend/config/S3Config.java
@@ -1,0 +1,37 @@
+package wap.dingdong.backend.config;
+
+import com.amazonaws.auth.AWSStaticCredentialsProvider;
+import com.amazonaws.auth.BasicAWSCredentials;
+import com.amazonaws.regions.Regions;
+import com.amazonaws.services.s3.AmazonS3;
+import com.amazonaws.services.s3.AmazonS3ClientBuilder;
+import lombok.Getter;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+@Getter
+public class S3Config {
+
+    @Value("${aws.accessKeyId}")
+    private String accessKeyId;
+
+    @Value("${aws.secretKey}")
+    private String secretKey;
+
+    @Value("${aws.s3.region}")
+    private String region;
+
+    @Value("${aws.s3.bucketName}")
+    private String bucketName;
+
+    @Bean
+    public AmazonS3 amazonS3() {
+        BasicAWSCredentials awsCredentials = new BasicAWSCredentials(accessKeyId, secretKey);
+        return AmazonS3ClientBuilder.standard()
+                .withRegion(Regions.fromName(region))
+                .withCredentials(new AWSStaticCredentialsProvider(awsCredentials))
+                .build();
+    }
+}

--- a/backend/src/main/java/wap/dingdong/backend/controller/ProductController.java
+++ b/backend/src/main/java/wap/dingdong/backend/controller/ProductController.java
@@ -24,14 +24,17 @@ public class ProductController {
 
     private final ProductService productService;
 
-    //상품등록
+    // 상품 등록
     @PostMapping("/product")
     public ResponseEntity<?> createProduct(@CurrentUser UserPrincipal userPrincipal,
-                                           @RequestPart("images") MultipartFile imageFile,
+                                           @RequestPart("imageFiles") List<MultipartFile> imageFiles,
                                            @RequestPart("product") ProductCreateRequest request) throws IOException {
-        productService.save(userPrincipal, imageFile, request);
+        // 이미지 파일들을 ProductCreateRequest 객체에 설정
+        request.setImageFiles(imageFiles);
+        productService.save(userPrincipal, request);
         return new ResponseEntity<>(HttpStatus.OK);
     }
+
 
 //    // 상품 상세보기
 //    //@GetMapping("/product/{productId}")

--- a/backend/src/main/java/wap/dingdong/backend/controller/ProductController.java
+++ b/backend/src/main/java/wap/dingdong/backend/controller/ProductController.java
@@ -4,6 +4,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
+import org.springframework.web.multipart.MultipartFile;
 import wap.dingdong.backend.domain.User;
 import wap.dingdong.backend.payload.request.ProductCreateRequest;
 import wap.dingdong.backend.payload.response.ProductInfoResponse;
@@ -14,6 +15,7 @@ import wap.dingdong.backend.security.CurrentUser;
 import wap.dingdong.backend.security.UserPrincipal;
 import wap.dingdong.backend.service.ProductService;
 
+import java.io.IOException;
 import java.util.List;
 
 @RequiredArgsConstructor
@@ -22,11 +24,12 @@ public class ProductController {
 
     private final ProductService productService;
 
-    //상품 등록
+    //상품등록
     @PostMapping("/product")
-    public ResponseEntity<?> createProduct(@CurrentUser UserPrincipal userPrincipal, //User 와 요청 DTO 를 별개로 취급
-                                           @RequestBody ProductCreateRequest request) {
-        productService.save(userPrincipal, request);
+    public ResponseEntity<?> createProduct(@CurrentUser UserPrincipal userPrincipal,
+                                           @RequestPart("images") MultipartFile imageFile,
+                                           @RequestPart("product") ProductCreateRequest request) throws IOException {
+        productService.save(userPrincipal, imageFile, request);
         return new ResponseEntity<>(HttpStatus.OK);
     }
 

--- a/backend/src/main/java/wap/dingdong/backend/controller/ProductController.java
+++ b/backend/src/main/java/wap/dingdong/backend/controller/ProductController.java
@@ -27,7 +27,7 @@ public class ProductController {
     // 상품 등록
     @PostMapping("/product")
     public ResponseEntity<?> createProduct(@CurrentUser UserPrincipal userPrincipal,
-                                           @RequestPart("imageFiles") List<MultipartFile> imageFiles,
+                                           @RequestPart("images") List<MultipartFile> imageFiles,
                                            @RequestPart("product") ProductCreateRequest request) throws IOException {
         // 이미지 파일들을 ProductCreateRequest 객체에 설정
         request.setImageFiles(imageFiles);

--- a/backend/src/main/java/wap/dingdong/backend/domain/ProductStatus.java
+++ b/backend/src/main/java/wap/dingdong/backend/domain/ProductStatus.java
@@ -1,5 +1,0 @@
-package wap.dingdong.backend.domain;
-
-public enum ProductStatus {
-    ON_SALE, SOLD_OUT
-}

--- a/backend/src/main/java/wap/dingdong/backend/payload/request/ProductCreateRequest.java
+++ b/backend/src/main/java/wap/dingdong/backend/payload/request/ProductCreateRequest.java
@@ -4,6 +4,7 @@ import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
+import org.springframework.web.multipart.MultipartFile;
 import wap.dingdong.backend.payload.ImageDto;
 import wap.dingdong.backend.payload.LocationDto;
 
@@ -20,6 +21,7 @@ public class ProductCreateRequest {
     private String contents;
     private List<LocationDto> locations;
     private List<ImageDto> images;
+    private List<MultipartFile> imageFiles;
 
 
     public ProductCreateRequest(List<ImageDto> imageDtos) {

--- a/backend/src/main/java/wap/dingdong/backend/payload/request/ProductCreateRequest.java
+++ b/backend/src/main/java/wap/dingdong/backend/payload/request/ProductCreateRequest.java
@@ -4,14 +4,13 @@ import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
-import wap.dingdong.backend.domain.Product;
 import wap.dingdong.backend.payload.ImageDto;
 import wap.dingdong.backend.payload.LocationDto;
-import wap.dingdong.backend.security.UserPrincipal;
 
 import java.util.List;
 
 @Getter
+@Setter
 @NoArgsConstructor
 @AllArgsConstructor
 public class ProductCreateRequest {
@@ -23,4 +22,7 @@ public class ProductCreateRequest {
     private List<ImageDto> images;
 
 
+    public ProductCreateRequest(List<ImageDto> imageDtos) {
+        this.images = imageDtos;
+    }
 }

--- a/backend/src/main/java/wap/dingdong/backend/service/ProductService.java
+++ b/backend/src/main/java/wap/dingdong/backend/service/ProductService.java
@@ -1,12 +1,19 @@
 package wap.dingdong.backend.service;
 
 
+import com.amazonaws.services.s3.AmazonS3;
+import com.amazonaws.services.s3.model.CannedAccessControlList;
+import com.amazonaws.services.s3.model.PutObjectRequest;
 import lombok.RequiredArgsConstructor;
+import lombok.Value;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.multipart.MultipartFile;
+import wap.dingdong.backend.config.S3Config;
 import wap.dingdong.backend.domain.*;
 import wap.dingdong.backend.exception.ResourceNotFoundException;
+import wap.dingdong.backend.payload.ImageDto;
 import wap.dingdong.backend.payload.request.CommentRequest;
 import wap.dingdong.backend.payload.request.ProductCreateRequest;
 import wap.dingdong.backend.payload.response.CommentResponse;
@@ -19,6 +26,7 @@ import wap.dingdong.backend.repository.ProductRepository;
 import wap.dingdong.backend.repository.UserRepository;
 import wap.dingdong.backend.security.UserPrincipal;
 
+import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.stream.Collectors;
@@ -29,33 +37,50 @@ public class ProductService {
 
     private final ProductRepository productRepository;
     private final UserRepository userRepository;
+    private final AmazonS3 amazonS3;
+    private final S3Config s3Config;
+
 
     /*
       상품 등록
    */
     @Transactional
-    public void save(UserPrincipal userPrincipal, ProductCreateRequest request) {
+    public void save(UserPrincipal userPrincipal, MultipartFile imageFile, ProductCreateRequest request) throws IOException {
+        User user = userRepository.findById(userPrincipal.getId()).orElseThrow(() -> new IllegalArgumentException("Invalid user Id"));
+        String imageUrl = uploadImageToS3(imageFile);
+        Product product = createProduct(user, request, imageUrl);
+        productRepository.save(product);
+    }
 
-        //요청토큰에 해당하는 user 를 꺼내옴
-        User user = userRepository.findById(userPrincipal.getId()).get();
+    private String uploadImageToS3(MultipartFile imageFile) throws IOException {
+        String fileName = System.currentTimeMillis() + "_" + imageFile.getOriginalFilename();
+        amazonS3.putObject(new PutObjectRequest(s3Config.getBucketName(), fileName, imageFile.getInputStream(), null)
+                .withCannedAcl(CannedAccessControlList.PublicRead));
+        return amazonS3.getUrl(s3Config.getBucketName(), fileName).toString();
+    }
 
-        //locationDto 를 location 엔티티객체로 변환 (DB 사용을 위해)
+    private Product createProduct(User user, ProductCreateRequest request, String imageUrl) {
         List<Location> locations = request.getLocations().stream()
                 .map(locationDto -> new Location(locationDto.getLocation()))
                 .collect(Collectors.toList());
+        // 이미지 URL을 사용하여 ImageDto 생성
+        List<ImageDto> imageDtos = new ArrayList<>();
+        imageDtos.add(new ImageDto(imageUrl)); // 이미지 URL 추가
 
-        List<Image> images = request.getImages().stream()
+        // ProductCreateRequest 객체 생성 및 초기화
+        ProductCreateRequest modifiedRequest = new ProductCreateRequest(imageDtos);
+
+        List<Image> images = modifiedRequest.getImages().stream()
                 .map(imageDto -> new Image(imageDto.getImage()))
                 .collect(Collectors.toList());
 
         Product product = new Product(user, request.getTitle(), request.getPrice(),
                 request.getContents(), locations, images);
 
-        // 양방향 연관관계 데이터 일관성 유지 : 연관관계의 주인이 아닌쪽의 엔티티가 변경되었을때 연관관계의 주인의 엔티티도 set
         locations.forEach(location -> location.updateProduct(product));
         images.forEach(image -> image.updateProduct(product));
 
-        productRepository.save(product);
+        return product;
     }
 
 


### PR DESCRIPTION
# 노션에 이미지 업로드 페이지와 상품등록 api명세서 확인할것
## 프런트
- multipart/form-data 형식으로 요청데이터를 보내야함 (바디에 다른형식의 데이터들을 분리해서 한번에 보내는 방식)
- http body에 이미지에 해당하는 MultipartFile과 나머지 JSON을 보내야함
- 이미지는 url 문자열로 저장됨
--------
## 백
- ddl auto create가 잘 작동이 안되므로 로컬에서 작업 시 application.properties에서 ddl auto를 update으로 설정하고 작업할것
- POSTMAN으로 요청하는 방법은 노션에 써놓음